### PR TITLE
feat: Add startup tray autostart option

### DIFF
--- a/DiscordRamLimiter/App.xaml.cs
+++ b/DiscordRamLimiter/App.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Runtime.Versioning;
+using DiscordRamLimiter.Services;
 
 namespace DiscordRamLimiter;
 
@@ -12,7 +13,8 @@ public partial class App : System.Windows.Application
     {
         base.OnStartup(e);
 
-        _mainWindow = new MainWindow();
+        var startMinimized = e.Args.Any(arg => string.Equals(arg, StartupService.MinimizedArgument, StringComparison.OrdinalIgnoreCase));
+        _mainWindow = new MainWindow(startMinimized);
         _mainWindow.Show();
     }
 

--- a/DiscordRamLimiter/MainWindow.xaml
+++ b/DiscordRamLimiter/MainWindow.xaml
@@ -3,9 +3,9 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Discord RAM Limiter"
         Width="430"
-        Height="590"
+        Height="600"
         MinWidth="430"
-        MinHeight="590"
+        MinHeight="600"
         ResizeMode="NoResize"
         WindowStartupLocation="CenterScreen"
         WindowStyle="None"
@@ -16,6 +16,46 @@
         Closing="Window_Closing"
         MouseLeftButtonDown="Window_MouseLeftButtonDown">
     <Window.Resources>
+        <Style x:Key="RoundCheckBoxStyle" TargetType="{x:Type CheckBox}">
+            <Setter Property="Foreground" Value="#AAB4CD" />
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type CheckBox}">
+                        <StackPanel Orientation="Horizontal">
+                            <Border x:Name="Circle"
+                            Width="18"
+                            Height="18"
+                            CornerRadius="9"
+                            BorderThickness="2"
+                            BorderBrush="#5865F2"
+                            Background="#1B2231">
+                                <Ellipse x:Name="Dot"
+                                 Width="8"
+                                 Height="8"
+                                 Fill="#36CE7D"
+                                 Opacity="0"
+                                 HorizontalAlignment="Center"
+                                 VerticalAlignment="Center" />
+                            </Border>
+                            <ContentPresenter Margin="8,0,0,0"
+                                      VerticalAlignment="Center" />
+                        </StackPanel>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="Dot" Property="Opacity" Value="1" />
+                                <Setter TargetName="Circle" Property="BorderBrush" Value="#36CE7D" />
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Circle" Property="Opacity" Value="0.8" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
         <Style x:Key="ChromeButtonStyle" TargetType="{x:Type Button}">
             <Setter Property="Width" Value="34" />
             <Setter Property="Height" Value="30" />
@@ -232,7 +272,7 @@
                     </Grid>
                 </Button>
 
-                <Border Margin="0,30,0,0"
+                <Border Margin="0,26,0,0"
                         Width="286"
                         CornerRadius="18"
                         Background="#1B2231"
@@ -259,6 +299,13 @@
                                    HorizontalAlignment="Center" />
                     </StackPanel>
                 </Border>
+
+                <CheckBox x:Name="AutoStartCheckBox"
+                          Content="Launch with Windows in tray"
+                          Margin="0,16,0,0"
+                          Click="AutoStartCheckBox_Click"
+                          Style="{StaticResource RoundCheckBoxStyle}"
+                          HorizontalAlignment="Center" />
             </StackPanel>
         </Grid>
     </Grid>

--- a/DiscordRamLimiter/MainWindow.xaml.cs
+++ b/DiscordRamLimiter/MainWindow.xaml.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Security;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -24,23 +25,35 @@ public partial class MainWindow : Window, IDisposable
     private readonly DiscordLimiterService _limiterService = new();
     private readonly Forms.NotifyIcon _trayIcon;
     private readonly Drawing.Icon? _customTrayIcon;
+    private readonly bool _startMinimized;
+    private readonly Forms.ToolStripMenuItem _startupMenuItem;
     private bool _isExitRequested;
     private bool _isMinimizingToTray;
 
-    public MainWindow()
+    public MainWindow(bool startMinimized = false)
     {
+        _startMinimized = startMinimized;
+
         InitializeComponent();
         ApplyWindowIcon();
 
         _customTrayIcon = LoadTrayIcon();
-        _trayIcon = BuildTrayIcon(_customTrayIcon);
+        _trayIcon = BuildTrayIcon(_customTrayIcon, out _startupMenuItem);
         _limiterService.SnapshotUpdated += LimiterService_SnapshotUpdated;
     }
 
     private async void Window_Loaded(object sender, RoutedEventArgs e)
     {
         await _limiterService.StartAsync();
-        AnimateToggle(isActive: false, durationMs: 1);
+        _limiterService.SetLimiterActive(_startMinimized);
+        AnimateToggle(_startMinimized, durationMs: 1);
+        UpdateStatus(_startMinimized);
+        RefreshStartupState();
+
+        if (_startMinimized)
+        {
+            MinimizeToTray(showNotification: false);
+        }
     }
 
     private void LimiterToggleButton_Click(object sender, RoutedEventArgs e)
@@ -141,10 +154,16 @@ public partial class MainWindow : Window, IDisposable
             : $"{megabytes:0.0} MB";
     }
 
-    private Forms.NotifyIcon BuildTrayIcon(Drawing.Icon? trayIcon)
+    private Forms.NotifyIcon BuildTrayIcon(Drawing.Icon? trayIcon, out Forms.ToolStripMenuItem startupMenuItem)
     {
         var menu = new Forms.ContextMenuStrip();
         menu.Items.Add("Open", null, (_, _) => ShowFromTray());
+        startupMenuItem = new Forms.ToolStripMenuItem("Launch at startup")
+        {
+            CheckOnClick = true
+        };
+        startupMenuItem.CheckedChanged += StartupMenuItem_CheckedChanged;
+        menu.Items.Add(startupMenuItem);
         menu.Items.Add("Exit", null, async (_, _) => await ExitApplicationAsync());
 
         var notifyIcon = new Forms.NotifyIcon
@@ -157,6 +176,57 @@ public partial class MainWindow : Window, IDisposable
 
         notifyIcon.DoubleClick += (_, _) => ShowFromTray();
         return notifyIcon;
+    }
+
+    private void AutoStartCheckBox_Click(object sender, RoutedEventArgs e)
+    {
+        SetLaunchAtStartup(AutoStartCheckBox.IsChecked == true);
+    }
+
+    private void StartupMenuItem_CheckedChanged(object? sender, EventArgs e)
+    {
+        SetLaunchAtStartup(_startupMenuItem.Checked);
+    }
+
+    private void RefreshStartupState()
+    {
+        var isEnabled = StartupService.IsLaunchAtStartupEnabled();
+        AutoStartCheckBox.IsChecked = isEnabled;
+        _startupMenuItem.CheckedChanged -= StartupMenuItem_CheckedChanged;
+        _startupMenuItem.Checked = isEnabled;
+        _startupMenuItem.CheckedChanged += StartupMenuItem_CheckedChanged;
+    }
+
+    private void SetLaunchAtStartup(bool isEnabled)
+    {
+        try
+        {
+            StartupService.SetLaunchAtStartup(isEnabled);
+            RefreshStartupState();
+        }
+        catch (UnauthorizedAccessException)
+        {
+            RefreshStartupState();
+            ShowStartupError();
+        }
+        catch (IOException)
+        {
+            RefreshStartupState();
+            ShowStartupError();
+        }
+        catch (SecurityException)
+        {
+            RefreshStartupState();
+            ShowStartupError();
+        }
+    }
+
+    private void ShowStartupError()
+    {
+        _trayIcon.BalloonTipTitle = "Discord RAM Limiter";
+        _trayIcon.BalloonTipText = "Could not update Windows startup settings.";
+        _trayIcon.BalloonTipIcon = Forms.ToolTipIcon.Warning;
+        _trayIcon.ShowBalloonTip(2200);
     }
 
     private static string GetAppIconPath()
@@ -296,9 +366,9 @@ public partial class MainWindow : Window, IDisposable
         MinimizeToTray();
     }
 
-    private void CloseButton_Click(object sender, RoutedEventArgs e)
+    private async void CloseButton_Click(object sender, RoutedEventArgs e)
     {
-        MinimizeToTray();
+        await ExitApplicationAsync();
     }
 
     private void Window_Closing(object? sender, CancelEventArgs e)
@@ -312,7 +382,7 @@ public partial class MainWindow : Window, IDisposable
         MinimizeToTray();
     }
 
-    private void MinimizeToTray()
+    private void MinimizeToTray(bool showNotification = true)
     {
         if (_isMinimizingToTray || !IsVisible)
         {
@@ -324,7 +394,10 @@ public partial class MainWindow : Window, IDisposable
         {
             WindowState = WindowState.Minimized;
             Hide();
-            ShowTrayNotification();
+            if (showNotification)
+            {
+                ShowTrayNotification();
+            }
         }
         finally
         {

--- a/DiscordRamLimiter/Services/StartupService.cs
+++ b/DiscordRamLimiter/Services/StartupService.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics;
+using System.IO;
+using Microsoft.Win32;
+
+namespace DiscordRamLimiter.Services;
+
+public static class StartupService
+{
+    public const string MinimizedArgument = "--minimized";
+
+    private const string RunKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Run";
+    private const string RunValueName = "DiscordRamLimiter";
+
+    public static bool IsLaunchAtStartupEnabled()
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: false);
+        return string.Equals(key?.GetValue(RunValueName) as string, GetStartupCommand(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static void SetLaunchAtStartup(bool isEnabled)
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: true)
+            ?? Registry.CurrentUser.CreateSubKey(RunKeyPath, writable: true);
+
+        if (isEnabled)
+        {
+            key.SetValue(RunValueName, GetStartupCommand(), RegistryValueKind.String);
+            return;
+        }
+
+        key.DeleteValue(RunValueName, throwOnMissingValue: false);
+    }
+
+    private static string GetStartupCommand()
+    {
+        var processPath = Environment.ProcessPath;
+
+        if (string.IsNullOrWhiteSpace(processPath) || !File.Exists(processPath))
+        {
+            processPath = Process.GetCurrentProcess().MainModule?.FileName;
+        }
+
+        if (string.IsNullOrWhiteSpace(processPath))
+        {
+            throw new InvalidOperationException("Unable to resolve the application path.");
+        }
+
+        return $"\"{processPath}\" {MinimizedArgument}";
+    }
+}


### PR DESCRIPTION
Adds a Windows startup toggle backed by the current-user Run registry key.

When enabled, the app launches with Windows using a --minimized argument, starts in the system tray, and enables the limiter automatically. Manual launches keep the limiter disabled by default.